### PR TITLE
065-img-preload set default image to 2x

### DIFF
--- a/src/components/Image/DynamicImage/DynamicImage.tsx
+++ b/src/components/Image/DynamicImage/DynamicImage.tsx
@@ -15,9 +15,17 @@ const DynamicImage = ({ image, breakpoints, preload = false }: ImageProps) => {
 
   const { url, description: alt, height: imgHeight, width: imgWidth } = image;
 
+  const defaultWidth = breakpoints[0].imgWidth;
+
   return breakpoints && url && imgWidth && imgHeight && alt ? (
     <>
-      {preload && <PreloadTags breakpoints={breakpoints} url={url} />}
+      {preload && (
+        <PreloadTags
+          breakpoints={breakpoints}
+          url={url}
+          defaultWidth={defaultWidth}
+        />
+      )}
       <picture>
         {breakpoints.map(({ viewMin, imgWidth }, index, breakpoints) => {
           return (
@@ -35,11 +43,11 @@ const DynamicImage = ({ image, breakpoints, preload = false }: ImageProps) => {
         })}
         <img
           alt={alt}
-          height={imgHeight}
+          height={defaultWidth * 0.75}
           loading={preload ? 'eager' : 'lazy'}
-          src={url}
+          src={`${url}?w={${defaultWidth * 2}&fm=webp}`}
           style={{ maxWidth: '100%', height: 'auto' }}
-          width={imgWidth}
+          width={defaultWidth}
         />
       </picture>
     </>

--- a/src/components/Image/DynamicImage/__snapshots__/DynamicImage.test.tsx.snap
+++ b/src/components/Image/DynamicImage/__snapshots__/DynamicImage.test.tsx.snap
@@ -4,49 +4,52 @@ exports[`DynamicImage when there is a url & image object it renders a picture co
 <div>
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="400px"
-    imagesrcset="https://URL.test?w=400&fm=webp&q=75 1x, https://URL.test?w=800&fm=webp&q=75 2x"
+    href="https://URL.test?w=800&fm=webp"
+    imagesrcset="https://URL.test?w=400&fm=webp 1x, https://URL.test?w=800&fm=webp 2x"
     media="(min-width: 1000px)"
     rel="preload"
+    sizes="400px"
+    type="image/webp"
   />
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="200px"
-    imagesrcset="https://URL.test?w=200&fm=webp&q=75 1x, https://URL.test?w=400&fm=webp&q=75 2x"
+    href="https://URL.test?w=800&fm=webp"
+    imagesrcset="https://URL.test?w=200&fm=webp 1x, https://URL.test?w=400&fm=webp 2x"
     media="(min-width: 500px) and (max-width: 999px)"
     rel="preload"
+    sizes="200px"
+    type="image/webp"
   />
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="100px"
-    imagesrcset="https://URL.test?w=100&fm=webp&q=75 1x, https://URL.test?w=200&fm=webp&q=75 2x"
+    href="https://URL.test?w=800&fm=webp"
+    imagesrcset="https://URL.test?w=100&fm=webp 1x, https://URL.test?w=200&fm=webp 2x"
     media="(max-width: 499px)"
     rel="preload"
+    sizes="100px"
+    type="image/webp"
   />
   <picture>
     <source
       media="(min-width: 1000px)"
       sizes="400px"
-      srcset="https://URL.test?w=400&fm=webp&q=75 1x, https://URL.test?w=800&fm=webp&q=75 2x"
+      srcset="https://URL.test?w=400&fm=webp 1x, https://URL.test?w=800&fm=webp 2x"
     />
     <source
       media="(min-width: 500px) and (max-width: 999px)"
       sizes="200px"
-      srcset="https://URL.test?w=200&fm=webp&q=75 1x, https://URL.test?w=400&fm=webp&q=75 2x"
+      srcset="https://URL.test?w=200&fm=webp 1x, https://URL.test?w=400&fm=webp 2x"
     />
     <source
       media="(max-width: 499px)"
       sizes="100px"
-      srcset="https://URL.test?w=100&fm=webp&q=75 1x, https://URL.test?w=200&fm=webp&q=75 2x"
+      srcset="https://URL.test?w=100&fm=webp 1x, https://URL.test?w=200&fm=webp 2x"
     />
     <img
       alt="Image Description"
       height="300"
       loading="eager"
-      src="https://URL.test"
+      src="https://URL.test?w={800&fm=webp}"
       style="max-width: 100%; height: auto;"
       width="400"
     />

--- a/src/components/Image/PreloadTags/PreloadTags.test.tsx
+++ b/src/components/Image/PreloadTags/PreloadTags.test.tsx
@@ -23,6 +23,8 @@ describe('PreloadTags', () => {
       },
     ];
 
+    const defaultWidth = breakpoints[0].imgWidth;
+
     it('it renders a set of preload link tags in a Head component', () => {
       const expectedImageSizes = '300px';
 
@@ -31,7 +33,11 @@ describe('PreloadTags', () => {
       const mediaQuerySpy = jest.spyOn(responsiveImage, 'createMediaQuery');
 
       const { container } = render(
-        <PreloadTags breakpoints={breakpoints} url={url} />
+        <PreloadTags
+          breakpoints={breakpoints}
+          url={url}
+          defaultWidth={defaultWidth}
+        />
       );
 
       //   expect srcSet and mediaQuery creators to be called
@@ -54,7 +60,13 @@ describe('PreloadTags', () => {
 
   describe('when props and url are provided', () => {
     it('it does not render', () => {
-      render(<PreloadTags breakpoints={[]} url={null as unknown as string} />);
+      render(
+        <PreloadTags
+          breakpoints={[]}
+          url={null as unknown as string}
+          defaultWidth={0}
+        />
+      );
 
       const linkTags = document.getElementsByTagName('link');
 

--- a/src/components/Image/PreloadTags/PreloadTags.tsx
+++ b/src/components/Image/PreloadTags/PreloadTags.tsx
@@ -4,9 +4,10 @@ import responsiveImage, { Breakpoints } from 'lib/responsiveImage';
 interface PreloadTagsProps {
   breakpoints: Breakpoints[];
   url: string;
+  defaultWidth: number;
 }
 
-const PreloadTags = ({ breakpoints, url }: PreloadTagsProps) => {
+const PreloadTags = ({ breakpoints, url, defaultWidth }: PreloadTagsProps) => {
   const { createSrcSet, createMediaQuery } = responsiveImage;
 
   return breakpoints && breakpoints.length > 0 && url ? (
@@ -16,9 +17,9 @@ const PreloadTags = ({ breakpoints, url }: PreloadTagsProps) => {
           url && (
             <link
               rel="preload"
-              href={url}
+              href={`${url}?w=${defaultWidth * 2}&fm=webp`}
               as="image"
-              imageSizes={`${imgWidth}px`}
+              sizes={`${imgWidth}px`}
               imageSrcSet={createSrcSet({ url, imgWidth })}
               key={`${url}-${viewMin || imgWidth}-preload`}
               media={createMediaQuery({
@@ -26,6 +27,7 @@ const PreloadTags = ({ breakpoints, url }: PreloadTagsProps) => {
                 index,
                 breakpoints,
               })}
+              type="image/webp"
             />
           )
       )}

--- a/src/components/Image/PreloadTags/__snapshots__/PreloadTags.test.tsx.snap
+++ b/src/components/Image/PreloadTags/__snapshots__/PreloadTags.test.tsx.snap
@@ -4,27 +4,30 @@ exports[`PreloadTags when props and url are provided it renders a set of preload
 <div>
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="300px"
-    imagesrcset="https://URL.test?w=300&fm=webp&q=75 1x, https://URL.test?w=600&fm=webp&q=75 2x"
+    href="https://URL.test?w=600&fm=webp"
+    imagesrcset="https://URL.test?w=300&fm=webp 1x, https://URL.test?w=600&fm=webp 2x"
     media="(min-width: 1000px)"
     rel="preload"
+    sizes="300px"
+    type="image/webp"
   />
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="200px"
-    imagesrcset="https://URL.test?w=200&fm=webp&q=75 1x, https://URL.test?w=400&fm=webp&q=75 2x"
+    href="https://URL.test?w=600&fm=webp"
+    imagesrcset="https://URL.test?w=200&fm=webp 1x, https://URL.test?w=400&fm=webp 2x"
     media="(min-width: 500px) and (max-width: 999px)"
     rel="preload"
+    sizes="200px"
+    type="image/webp"
   />
   <link
     as="image"
-    href="https://URL.test"
-    imagesizes="100px"
-    imagesrcset="https://URL.test?w=100&fm=webp&q=75 1x, https://URL.test?w=200&fm=webp&q=75 2x"
+    href="https://URL.test?w=600&fm=webp"
+    imagesrcset="https://URL.test?w=100&fm=webp 1x, https://URL.test?w=200&fm=webp 2x"
     media="(max-width: 499px)"
     rel="preload"
+    sizes="100px"
+    type="image/webp"
   />
 </div>
 `;

--- a/src/components/RecipeCard/__snapshots__/RecipeCard.test.tsx.snap
+++ b/src/components/RecipeCard/__snapshots__/RecipeCard.test.tsx.snap
@@ -36,77 +36,82 @@ exports[`RecipeCard when there is content it renders the RecipeCard 1`] = `
         >
           <link
             as="image"
-            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
-            imagesizes="450px"
-            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp&q=75 2x"
+            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp"
+            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp 2x"
             media="(min-width: 669px)"
             rel="preload"
+            sizes="450px"
+            type="image/webp"
           />
           <link
             as="image"
-            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
-            imagesizes="300px"
-            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 2x"
+            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp"
+            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 2x"
             media="(min-width: 600px) and (max-width: 668px)"
             rel="preload"
+            sizes="300px"
+            type="image/webp"
           />
           <link
             as="image"
-            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
-            imagesizes="600px"
-            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=1200&fm=webp&q=75 2x"
+            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp"
+            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=1200&fm=webp 2x"
             media="(min-width: 485px) and (max-width: 599px)"
             rel="preload"
+            sizes="600px"
+            type="image/webp"
           />
           <link
             as="image"
-            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
-            imagesizes="450px"
-            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp&q=75 2x"
+            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp"
+            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp 2x"
             media="(min-width: 335px) and (max-width: 484px)"
             rel="preload"
+            sizes="450px"
+            type="image/webp"
           />
           <link
             as="image"
-            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
-            imagesizes="300px"
-            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 2x"
+            href="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp"
+            imagesrcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 2x"
             media="(max-width: 334px)"
             rel="preload"
+            sizes="300px"
+            type="image/webp"
           />
           <picture>
             <source
               media="(min-width: 669px)"
               sizes="450px"
-              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp&q=75 2x"
+              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp 2x"
             />
             <source
               media="(min-width: 600px) and (max-width: 668px)"
               sizes="300px"
-              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 2x"
+              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 2x"
             />
             <source
               media="(min-width: 485px) and (max-width: 599px)"
               sizes="600px"
-              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=1200&fm=webp&q=75 2x"
+              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=1200&fm=webp 2x"
             />
             <source
               media="(min-width: 335px) and (max-width: 484px)"
               sizes="450px"
-              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp&q=75 2x"
+              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=450&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=900&fm=webp 2x"
             />
             <source
               media="(max-width: 334px)"
               sizes="300px"
-              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp&q=75 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp&q=75 2x"
+              srcset="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=300&fm=webp 1x, https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w=600&fm=webp 2x"
             />
             <img
               alt="Skillet with basmati rice and chopped parsley."
-              height="3024"
+              height="337.5"
               loading="eager"
-              src="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg"
+              src="https://images.ctfassets.net/fo9qwg6zarbt/2Y8FHjjNDYCcsflAJq4Q5j/6615d77fa788a39e5d9135b9def8d006/basmati-rice.jpg?w={900&fm=webp}"
               style="max-width: 100%; height: auto;"
-              width="4032"
+              width="450"
             />
           </picture>
         </div>

--- a/src/layout/RecipePage/__snapshots__/RecipePage.test.tsx.snap
+++ b/src/layout/RecipePage/__snapshots__/RecipePage.test.tsx.snap
@@ -49,77 +49,82 @@ exports[`Recipe when there is page content it renders the Recipe 1`] = `
     >
       <link
         as="image"
-        href="https://recipes.pliddy.com/url"
-        imagesizes="900px"
-        imagesrcset="https://recipes.pliddy.com/url?w=900&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1800&fm=webp&q=75 2x"
+        href="https://recipes.pliddy.com/url?w=1800&fm=webp"
+        imagesrcset="https://recipes.pliddy.com/url?w=900&fm=webp 1x, https://recipes.pliddy.com/url?w=1800&fm=webp 2x"
         media="(min-width: 831px)"
         rel="preload"
+        sizes="900px"
+        type="image/webp"
       />
       <link
         as="image"
-        href="https://recipes.pliddy.com/url"
-        imagesizes="750px"
-        imagesrcset="https://recipes.pliddy.com/url?w=750&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1500&fm=webp&q=75 2x"
+        href="https://recipes.pliddy.com/url?w=1800&fm=webp"
+        imagesrcset="https://recipes.pliddy.com/url?w=750&fm=webp 1x, https://recipes.pliddy.com/url?w=1500&fm=webp 2x"
         media="(min-width: 665px) and (max-width: 830px)"
         rel="preload"
+        sizes="750px"
+        type="image/webp"
       />
       <link
         as="image"
-        href="https://recipes.pliddy.com/url"
-        imagesizes="600px"
-        imagesrcset="https://recipes.pliddy.com/url?w=600&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1200&fm=webp&q=75 2x"
+        href="https://recipes.pliddy.com/url?w=1800&fm=webp"
+        imagesrcset="https://recipes.pliddy.com/url?w=600&fm=webp 1x, https://recipes.pliddy.com/url?w=1200&fm=webp 2x"
         media="(min-width: 483px) and (max-width: 664px)"
         rel="preload"
+        sizes="600px"
+        type="image/webp"
       />
       <link
         as="image"
-        href="https://recipes.pliddy.com/url"
-        imagesizes="450px"
-        imagesrcset="https://recipes.pliddy.com/url?w=450&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=900&fm=webp&q=75 2x"
+        href="https://recipes.pliddy.com/url?w=1800&fm=webp"
+        imagesrcset="https://recipes.pliddy.com/url?w=450&fm=webp 1x, https://recipes.pliddy.com/url?w=900&fm=webp 2x"
         media="(min-width: 333px) and (max-width: 482px)"
         rel="preload"
+        sizes="450px"
+        type="image/webp"
       />
       <link
         as="image"
-        href="https://recipes.pliddy.com/url"
-        imagesizes="300px"
-        imagesrcset="https://recipes.pliddy.com/url?w=300&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=600&fm=webp&q=75 2x"
+        href="https://recipes.pliddy.com/url?w=1800&fm=webp"
+        imagesrcset="https://recipes.pliddy.com/url?w=300&fm=webp 1x, https://recipes.pliddy.com/url?w=600&fm=webp 2x"
         media="(max-width: 332px)"
         rel="preload"
+        sizes="300px"
+        type="image/webp"
       />
       <picture>
         <source
           media="(min-width: 831px)"
           sizes="900px"
-          srcset="https://recipes.pliddy.com/url?w=900&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1800&fm=webp&q=75 2x"
+          srcset="https://recipes.pliddy.com/url?w=900&fm=webp 1x, https://recipes.pliddy.com/url?w=1800&fm=webp 2x"
         />
         <source
           media="(min-width: 665px) and (max-width: 830px)"
           sizes="750px"
-          srcset="https://recipes.pliddy.com/url?w=750&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1500&fm=webp&q=75 2x"
+          srcset="https://recipes.pliddy.com/url?w=750&fm=webp 1x, https://recipes.pliddy.com/url?w=1500&fm=webp 2x"
         />
         <source
           media="(min-width: 483px) and (max-width: 664px)"
           sizes="600px"
-          srcset="https://recipes.pliddy.com/url?w=600&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=1200&fm=webp&q=75 2x"
+          srcset="https://recipes.pliddy.com/url?w=600&fm=webp 1x, https://recipes.pliddy.com/url?w=1200&fm=webp 2x"
         />
         <source
           media="(min-width: 333px) and (max-width: 482px)"
           sizes="450px"
-          srcset="https://recipes.pliddy.com/url?w=450&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=900&fm=webp&q=75 2x"
+          srcset="https://recipes.pliddy.com/url?w=450&fm=webp 1x, https://recipes.pliddy.com/url?w=900&fm=webp 2x"
         />
         <source
           media="(max-width: 332px)"
           sizes="300px"
-          srcset="https://recipes.pliddy.com/url?w=300&fm=webp&q=75 1x, https://recipes.pliddy.com/url?w=600&fm=webp&q=75 2x"
+          srcset="https://recipes.pliddy.com/url?w=300&fm=webp 1x, https://recipes.pliddy.com/url?w=600&fm=webp 2x"
         />
         <img
           alt="Image description."
-          height="300"
+          height="675"
           loading="eager"
-          src="https://recipes.pliddy.com/url"
+          src="https://recipes.pliddy.com/url?w={1800&fm=webp}"
           style="max-width: 100%; height: auto;"
-          width="400"
+          width="900"
         />
       </picture>
     </div>

--- a/src/lib/responsiveImage.test.ts
+++ b/src/lib/responsiveImage.test.ts
@@ -10,7 +10,7 @@ describe('responsiveImage', () => {
       const url = 'https://URL.test';
       const imgWidth = 1000;
       const expected =
-        'https://URL.test?w=1000&fm=webp&q=75 1x, https://URL.test?w=2000&fm=webp&q=75 2x';
+        'https://URL.test?w=1000&fm=webp 1x, https://URL.test?w=2000&fm=webp 2x';
 
       const srcSet = createSrcSet({ url, imgWidth });
 

--- a/src/lib/responsiveImage.ts
+++ b/src/lib/responsiveImage.ts
@@ -17,9 +17,9 @@ export interface createMediaQueryProps {
 export const createSrcSet = ({ url, imgWidth }: createSrcSetProps) => {
   return (
     url &&
-    `${url}?${imgWidth && `w=${imgWidth}&`}fm=webp&q=75 1x, ${url}?${
+    `${url}?${imgWidth && `w=${imgWidth}&`}fm=webp 1x, ${url}?${
       imgWidth && `w=${imgWidth * 2}&`
-    }fm=webp&q=75 2x`
+    }fm=webp 2x`
   );
 };
 


### PR DESCRIPTION
* works in Chrome, Safari, and Edge
* Firefox complains and doesn't preload correctly